### PR TITLE
Karate 0.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,15 +87,9 @@
         <!-- Karate Dependencies -->
         <dependency>
             <groupId>com.intuit.karate</groupId>
-            <artifactId>karate-apache</artifactId>
+            <artifactId>karate-core</artifactId>
             <version>${karate.version}</version>
             <scope>test</scope>
-<!--            <exclusions>-->
-<!--                <exclusion>-->
-<!--                    <artifactId>logback-core</artifactId>-->
-<!--                    <groupId>ch.qos.logback</groupId>-->
-<!--                </exclusion>-->
-<!--            </exclusions>-->
         </dependency>
         <dependency>
             <groupId>com.intuit.karate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,12 @@
     <name>spock-karate-example</name>
     <description>Demo project for Spring Boot</description>
     <properties>
-        <java.version>11</java.version>
-        <spock.version>2.0-M2-groovy-2.5</spock.version>
-        <groovy.version>2.5.10</groovy.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <spock.version>2.0-M5-groovy-2.5</spock.version>
+        <groovy.version>2.5.14</groovy.version>
         <karate.version>0.9.5</karate.version>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -145,25 +145,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.6.2</version>
-                <configuration>
-                    <sources>
-                        <source>
-                            <directory>${project.basedir}/src/test/java</directory>
-                            <includes>
-                                <include>**/*.groovy</include>
-                            </includes>
-                        </source>
-                    </sources>
-                    <testSources>
-                        <testSource>
-                            <directory>${project.basedir}/src/test/java</directory>
-                            <includes>
-                                <include>**/*.groovy</include>
-                            </includes>
-                        </testSource>
-                    </testSources>
-                </configuration>
+                <version>1.12.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/test/groovy/com/example/spock/karate/ApiTestRunnerSpec.groovy
+++ b/src/test/groovy/com/example/spock/karate/ApiTestRunnerSpec.groovy
@@ -31,8 +31,10 @@ class ApiTestRunnerSpec extends Specification {
         then:
         results != null
         1 * messageLogger.logMessage(_ as String) >> { String message ->
+            println "### message = $message"
             assert message != null
-            System.setProperty("message", message)
+            System.setProperty('message', message)
+            println "### " + System.getProperty('message')
         }
     }
 }


### PR DESCRIPTION
Upgrade some stuff and use Karate dependencies which can be used identically for 1.0.1, so that you only need to switch the version number in order to reproduce the problem.