### PR TITLE
Karate 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
  mvn -Dtest=ApiTestRunnerSpec test
+ 
+  search output for 'message value' - without quotes.  With version 0.9.5 value is 'Important Message'.  The value is being set in ApiTestRunnerSpec.groovy.

--- a/pom.xml
+++ b/pom.xml
@@ -87,15 +87,9 @@
         <!-- Karate Dependencies -->
         <dependency>
             <groupId>com.intuit.karate</groupId>
-            <artifactId>karate-apache</artifactId>
+            <artifactId>karate-core</artifactId>
             <version>${karate.version}</version>
             <scope>test</scope>
-<!--            <exclusions>-->
-<!--                <exclusion>-->
-<!--                    <artifactId>logback-core</artifactId>-->
-<!--                    <groupId>ch.qos.logback</groupId>-->
-<!--                </exclusion>-->
-<!--            </exclusions>-->
         </dependency>
         <dependency>
             <groupId>com.intuit.karate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,12 @@
     <name>spock-karate-example</name>
     <description>Demo project for Spring Boot</description>
     <properties>
-        <java.version>11</java.version>
-        <spock.version>2.0-M2-groovy-2.5</spock.version>
-        <groovy.version>2.5.10</groovy.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <spock.version>2.0-M5-groovy-2.5</spock.version>
+        <groovy.version>2.5.14</groovy.version>
         <karate.version>0.9.5</karate.version>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -145,25 +145,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.6.2</version>
-                <configuration>
-                    <sources>
-                        <source>
-                            <directory>${project.basedir}/src/test/java</directory>
-                            <includes>
-                                <include>**/*.groovy</include>
-                            </includes>
-                        </source>
-                    </sources>
-                    <testSources>
-                        <testSource>
-                            <directory>${project.basedir}/src/test/java</directory>
-                            <includes>
-                                <include>**/*.groovy</include>
-                            </includes>
-                        </testSource>
-                    </testSources>
-                </configuration>
+                <version>1.12.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/resources/Message.feature
+++ b/src/main/resources/Message.feature
@@ -12,4 +12,12 @@ Feature: Test Message
   Then status 200
 
   * print 'foo value ' + karate.properties['foo']
-  * print 'message value ' + karate.properties['message']
+  * def getMessage =
+    """
+    function() {
+      var MessageHolder = Java.type('com.example.spock.karate.ApiTestRunnerSpec.MessageHolder');
+      return MessageHolder.INSTANCE.getMessage();
+    }
+    """
+  * def message = call getMessage {}
+  * print 'message value ' + message

--- a/src/main/resources/Message.feature
+++ b/src/main/resources/Message.feature
@@ -12,12 +12,5 @@ Feature: Test Message
   Then status 200
 
   * print 'foo value ' + karate.properties['foo']
-  * def getMessage =
-    """
-    function() {
-      var MessageHolder = Java.type('com.example.spock.karate.ApiTestRunnerSpec.MessageHolder');
-      return MessageHolder.INSTANCE.getMessage();
-    }
-    """
-  * def message = call getMessage {}
-  * print 'message value ' + message
+  * def getMessage = function() { return Java.type('java.lang.System').getProperty('message'); }
+  * print 'message value ' + getMessage()

--- a/src/test/groovy/com/example/spock/karate/ApiTestRunnerSpec.groovy
+++ b/src/test/groovy/com/example/spock/karate/ApiTestRunnerSpec.groovy
@@ -31,8 +31,10 @@ class ApiTestRunnerSpec extends Specification {
         then:
         results != null
         1 * messageLogger.logMessage(_ as String) >> { String message ->
+            println "### message = $message"
             assert message != null
-            System.setProperty("message", message)
+            System.setProperty('message', message)
+            println "### " + System.getProperty('message')
         }
     }
 }

--- a/src/test/groovy/com/example/spock/karate/ApiTestRunnerSpec.groovy
+++ b/src/test/groovy/com/example/spock/karate/ApiTestRunnerSpec.groovy
@@ -1,6 +1,5 @@
 package com.example.spock.karate
 
-import com.intuit.karate.Results
 import com.intuit.karate.Runner
 import org.spockframework.spring.SpringBean
 import org.springframework.boot.test.context.SpringBootTest
@@ -17,7 +16,7 @@ class ApiTestRunnerSpec extends Specification {
     MessageLogger messageLogger = Mock() {
         1 * logMessage(_ as String) >> { String message ->
             assert message != null
-            MessageHolder.INSTANCE.message = message
+            System.setProperty('message', message)
         }
     }
 
@@ -27,29 +26,7 @@ class ApiTestRunnerSpec extends Specification {
     }
 
     def "Run Mock ApiTest"() {
-        given:
-        Results results = Runner
-          .path("classpath:")
-          .systemProperty("foo", "bar")
-          .tags("~@ignore")
-          .parallel(5)
-
         expect:
-        results
-    }
-    
-    static class MessageHolder {
-        public static final MessageHolder INSTANCE = new MessageHolder()
-        private String message
-
-        private MessageHolder() {}
-
-        String getMessage() {
-            return message
-        }
-
-        void setMessage(String message) {
-            this.message = message
-        }
+        Runner.path("classpath:").systemProperty("foo", "bar").tags("~@ignore").parallel(5)
     }
 }


### PR DESCRIPTION
Exactly the same Maven POM as in #1, only the Karate version number is different. This way when you open a Karate issue, nobody can tell you that the behavioral change originates in different dependencies. Before, in both branches you had different POMs.